### PR TITLE
It seems these lifetimes are not needed. So let's remove them to simplify life for library users

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub trait IteratorExt {
     fn parallel_map<F, O>(self, f: F) -> ParallelMap<Self, O>
     where
         Self: Sized,
-        Self: Iterator + 'static,
+        Self: Iterator,
         F: 'static + Send + Clone,
         Self::Item: Send + 'static,
         F: FnMut(Self::Item) -> O,
@@ -52,7 +52,7 @@ pub trait IteratorExt {
     fn parallel_map_custom<F, O, OF>(self, of: OF, f: F) -> ParallelMap<Self, O>
     where
         Self: Sized,
-        Self: Iterator + 'static,
+        Self: Iterator,
         F: 'static + Send + Clone,
         F: FnMut(Self::Item) -> O,
         Self::Item: Send + 'static,
@@ -73,7 +73,7 @@ pub trait IteratorExt {
     ) -> ParallelMap<Self, O>
     where
         Self: Sized,
-        Self: Iterator + 'env,
+        Self: Iterator,
         F: 'env + Send + Clone,
         Self::Item: Send + 'env,
         F: FnMut(Self::Item) -> O,
@@ -91,7 +91,7 @@ pub trait IteratorExt {
     ) -> ParallelMap<Self, O>
     where
         Self: Sized,
-        Self: Iterator + 'env,
+        Self: Iterator,
         F: 'env + Send + Clone,
         Self::Item: Send + 'env,
         F: FnMut(Self::Item) -> O,
@@ -107,7 +107,7 @@ pub trait IteratorExt {
     fn parallel_filter<F>(self, f: F) -> ParallelFilter<Self>
     where
         Self: Sized,
-        Self: Iterator + 'static,
+        Self: Iterator,
         F: 'static + Send + Clone,
         Self::Item: Send + 'static,
         F: FnMut(&Self::Item) -> bool,
@@ -119,7 +119,7 @@ pub trait IteratorExt {
     fn parallel_filter_custom<F, OF>(self, of: OF, f: F) -> ParallelFilter<Self>
     where
         Self: Sized,
-        Self: Iterator + 'static,
+        Self: Iterator,
         F: 'static + Send + Clone,
         Self::Item: Send + 'static,
         F: FnMut(&Self::Item) -> bool,
@@ -136,7 +136,7 @@ pub trait IteratorExt {
     ) -> ParallelFilter<Self>
     where
         Self: Sized,
-        Self: Iterator + 'env,
+        Self: Iterator,
         F: 'env + Send + Clone,
         Self::Item: Send + 'env,
         F: FnMut(&Self::Item) -> bool,
@@ -153,7 +153,7 @@ pub trait IteratorExt {
     ) -> ParallelFilter<Self>
     where
         Self: Sized,
-        Self: Iterator + 'env,
+        Self: Iterator,
         F: 'env + Send + Clone,
         Self::Item: Send + 'env,
         F: FnMut(&Self::Item) -> bool,

--- a/src/parallel_filter.rs
+++ b/src/parallel_filter.rs
@@ -21,7 +21,7 @@ where
 
     pub fn with<F>(self, mut f: F) -> ParallelFilter<I>
     where
-        I: Iterator + 'static,
+        I: Iterator,
         F: 'static + Send + Clone,
         I::Item: Send + 'static,
         F: FnMut(&I::Item) -> bool,
@@ -37,7 +37,7 @@ where
         mut f: F,
     ) -> ParallelFilter<I>
     where
-        I: Iterator + 'env,
+        I: Iterator,
         F: 'env + Send + Clone,
         I::Item: Send + 'env,
         F: FnMut(&I::Item) -> bool + 'env + Send,

--- a/src/parallel_map.rs
+++ b/src/parallel_map.rs
@@ -104,7 +104,7 @@ where
 
     pub fn with<F, O>(self, f: F) -> ParallelMap<I, O>
     where
-        I: Iterator + 'static,
+        I: Iterator,
         F: 'static + Send + Clone,
         O: Send + 'static,
         I::Item: Send + 'static,
@@ -137,7 +137,7 @@ where
         f: F,
     ) -> ParallelMap<I, O>
     where
-        I: Iterator + 'env,
+        I: Iterator,
         F: 'env + Send + Clone,
         O: Send + 'env,
         I::Item: Send + 'env,


### PR DESCRIPTION
I removed these lifetimes and pariter still compiles, so I assume all is okay. Removing these lifetimes simplify my program (now I don't need scopes). I can show you my code, if you want